### PR TITLE
Allow Hiera merge lookup types

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,9 +3,9 @@
 class accounts(
   $manage_users       = hiera('accounts::manage_users', true),
   $manage_groups      = hiera('accounts::manage_groups', true),
-  $users              = hiera_hash('accounts::users', {}),
-  $groups             = hiera_hash('accounts::groups', {}),
 ) {
+  $users              = hiera_hash('accounts::users', {})
+  $groups             = hiera_hash('accounts::groups', {})
 
   class { 'accounts::groups':
     manage => $manage_groups,


### PR DESCRIPTION
I believe [HI-118](https://tickets.puppetlabs.com/browse/HI-118) prevents merge lookup types from operating as expected when hiera_hash or hiera_array is called within the class parameters section.

This prevents the $users variable from being passed in as a parameter, but shouldn't we be modeling this data in Hiera anyway?
