### PR TITLE
quoted title variable in comment parameter

### DIFF
--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -4,7 +4,7 @@ define accounts::user(
   $uid = undef,
   $gid = $uid,
   $groups = [],
-  $comment = $title,
+  $comment = "${title}",
   $ssh_key = '',
   $ssh_keys = {},
   $shell ='/bin/bash',


### PR DESCRIPTION

I raised https://tickets.puppetlabs.com/browse/PUP-4332 today - although the example code is cut down I came across the issue trying to implement your module - for now, this is the fix I've put in to get around the problem.

I'm curious if you noted similar behaviour...

