### PR TITLE
Added the ability to manage the root pw without a home

### DIFF
--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -27,9 +27,11 @@ define accounts::user(
   validate_hash($ssh_keys)
   validate_bool($managehome)
 
-  $home_dir = $home ? {
-    undef   => "/home/${username}",
-    default => $home,
+  if ! $home {
+    $home_dir = $username ? {
+      root    => '/root',
+      default => "/home/${username}",
+    }
   }
 
   User <| title == $username |> { managehome => $managehome }


### PR DESCRIPTION
In the current version it is necessary to provide the user home of root
as otherwise the puppet run will fail. This happens because the module
tries to alter the home of the user to /home/root.