### PR TITLE
Added possibility to manage group members of a group

### DIFF
--- a/manifests/group.pp
+++ b/manifests/group.pp
@@ -3,6 +3,7 @@
 define accounts::group (
   $groupname = $title,
   $ensure    = 'present',
+  $members   = undef,
   $gid       = undef,
 ) {
 
@@ -11,7 +12,8 @@ define accounts::group (
 
   # avoid problems when group declared elsewhere
   ensure_resource('group', $groupname, {
-    'ensure' => $ensure,
-    'gid'    => $gid,
+    'ensure'  => $ensure,
+    'gid'     => $gid,
+    'members' => $members,
   })
 }

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -6,6 +6,7 @@ define accounts::user(
   $primary_group = "${title}", # intentionally, workaround for: https://tickets.puppetlabs.com/browse/PUP-4332
   $comment = "${title}", # see https://github.com/deric/puppet-accounts/pull/11
   $username = "${title}",# for more details
+  $group_members = undef,
   $groups = [],
   $ssh_key = '',
   $ssh_keys = {},
@@ -74,6 +75,7 @@ define accounts::user(
         ensure_resource('group', $primary_group, {
           'ensure' => 'present',
           'gid'    => $gid,
+          'members' => $group_members,
           'before' => Anchor["accounts::user::groups::${primary_group}"]
         })
       }

--- a/metadata.json
+++ b/metadata.json
@@ -12,6 +12,10 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.2.0"
+    },
+    {
+      "name": "onyxpoint/gpasswd",
+      "version_requirement": ">= 0.1.2"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
We're using onyxpoint/gpasswd to enable the management of group members
(for example ad users as members of a local group). The
onyxpoint/gpasswd module does that by overwriting parts of the group
provider. Changes to user.pp was necessary so that members of the
primary group of a user could be managed as well.