### PR TITLE
Add user type parameter 'purge_ssh_keys' to the account::user class.

### DIFF
--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -9,6 +9,7 @@ define accounts::user(
   $groups = [],
   $ssh_key = '',
   $ssh_keys = {},
+  $purge_ssh_keys = false,
   $shell ='/bin/bash',
   $pwhash = '',
   $managehome = true,
@@ -27,6 +28,9 @@ define accounts::user(
     'The $ensure parameter must be \'absent\' or \'present\'')
   validate_hash($ssh_keys)
   validate_bool($managehome)
+  if ! is_array($purge_ssh_keys) {
+    validate_bool($purge_ssh_keys)
+  }
 
   if $home {
     $home_dir = $home
@@ -79,13 +83,14 @@ define accounts::user(
       }
 
       user { $username:
-        ensure  => present,
-        uid     => $uid,
-        gid     => $gid,
-        groups  => $groups,
-        shell   => $shell,
-        comment => $comment,
-        require => [
+        ensure         => present,
+        uid            => $uid,
+        gid            => $gid,
+        groups         => $groups,
+        shell          => $shell,
+        comment        => $comment,
+        purge_ssh_keys => $purge_ssh_keys,
+        require        => [
           Anchor["accounts::user::groups::${primary_group}"]
         ],
       }


### PR DESCRIPTION
I did not specify a Rspec test, as I think the validation does not need to be tested and the correctness of purge_ssh_keys in user should not be validated here (already done in https://github.com/puppetlabs/puppet/blob/master/spec/unit/type/user_spec.rb)

Would be glad if you could merge this.
If you would like me to add some more doc / ..., please respond here. :)