### PR TITLE
Add some more configuration to spec_helper.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,10 +6,14 @@ include RspecPuppetFacts
 Puppet::Util::Log.level = :debug
 Puppet::Util::Log.newdestination(:console)
 
+fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
 RSpec.configure do |c|
   #c.treat_symbols_as_metadata_keys_with_true_values = true
   c.include PuppetlabsSpec::Files
   c.hiera_config = 'spec/fixtures/hiera/hiera.yaml'
+  c.module_path = File.join(fixture_path, 'modules')
+  c.manifest_dir = File.join(fixture_path, 'manifests')
+  c.template_dir = File.join(fixture_path, 'templates')
 end
 
 at_exit { RSpec::Puppet::Coverage.report! }


### PR DESCRIPTION
We need to explicitly set the module_dir, manifest_dir and template_dir for RSpec,
as otherwise some environments don't execute tests as files are not found.
Closes #56.