### PR TITLE
Feature: allow to use cleartext passwords

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,4 +1,4 @@
 forge 'https://forgeapi.puppetlabs.com'
 
-mod 'puppetlabs-stdlib', '>= 4.2.0'
+mod 'puppetlabs-stdlib', '>= 4.6.0'
 mod 'deric-gpasswd', '>= 0.2.2'

--- a/lib/facter/salts.rb
+++ b/lib/facter/salts.rb
@@ -1,0 +1,23 @@
+Facter.add('salts') do
+  confine :kernel => "Linux"
+  confine { File.exist? '/etc/shadow' }
+  confine :facterversion do |version|
+    Gem::Version.new(version) >= Gem::Version.new('2.0.0')
+  end
+  # read
+  shadow = Facter::Util::Resolution.exec('cat /etc/shadow')
+  # split into line array
+  lines = shadow.split('\n')
+  # create a new hash for {username => salt}
+  salts = Hash.new
+  setcode do
+    # parse every line
+    lines.each do |l|
+      parts = l.split(':')
+      if parts[1].include? "$"
+        salts[parts[0]] = parts[1].split('$')[2]
+      end
+    end
+    salts
+  end
+end

--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.2.0 < 5.0.0"
+      "version_requirement": ">= 4.6.0 < 5.0.0"
     },
     {
       "name": "deric-gpasswd",

--- a/spec/defines/user_spec.rb
+++ b/spec/defines/user_spec.rb
@@ -454,4 +454,62 @@ describe 'accounts::user', :type => :define do
 
   end
 
+  context 'set pwhash' do
+    let(:title) { 'foo' }
+    let(:params) do
+      {
+        pwhash: '$6$S0V3h4DIBzbCl6R4$v8LQvd8EGNo2jyTpJAx6kPC/E9Yd0wPtYTWguYI2JhmOV.Lmxg0d0skcP2IXDN3OU9jibaeUpjTLk66NCu3pT.',
+      }
+    end
+
+    it { is_expected.to contain_user('foo').with(
+      'name'     => 'foo',
+      'password' => '$6$S0V3h4DIBzbCl6R4$v8LQvd8EGNo2jyTpJAx6kPC/E9Yd0wPtYTWguYI2JhmOV.Lmxg0d0skcP2IXDN3OU9jibaeUpjTLk66NCu3pT.',
+    )}
+  end
+
+  context 'set cleartext password' do
+    let(:title) { 'foo' }
+
+    describe 'with pwhash set' do
+      let(:params) do
+        {
+          password: 'test1234',
+          pwhash:   '$6$S0V3h4DIBzbCl6R4$v8LQvd8EGNo2jyTpJAx6kPC/E9Yd0wPtYTWguYI2JhmOV.Lmxg0d0skcP2IXDN3OU9jibaeUpjTLk66NCu3pT.',
+        }
+      end
+      it { is_expected.to compile.and_raise_error(/You cannot set both \$pwhash and \$password/) }
+    end
+    describe 'without salt' do
+      let(:params) do
+        {
+          password: 'test1234',
+        }
+      end
+      it { is_expected.to compile.and_raise_error(/You need to specify a salt for hashing cleartext passwords./) }
+    end
+    describe 'with salt' do
+      let(:params) do
+        {
+          password: 'test1234',
+          salt: 'S0V3h4DIBzbCl6R4',
+        }
+      end
+      it { is_expected.to contain_user('foo').with(
+        'name'     => 'foo',
+        'password' => '$6$S0V3h4DIBzbCl6R4$v8LQvd8EGNo2jyTpJAx6kPC/E9Yd0wPtYTWguYI2JhmOV.Lmxg0d0skcP2IXDN3OU9jibaeUpjTLk66NCu3pT.',
+      )}
+    end
+    describe 'with undef hash' do
+      let(:params){{
+        :password => 'test1234',
+        :salt => 'S0V3h4DIBzbCl6R4',
+        :hash => :undef,
+      }}
+      it { is_expected.to contain_user('foo').with(
+        'name'     => 'foo',
+        'password' => '$6$S0V3h4DIBzbCl6R4$v8LQvd8EGNo2jyTpJAx6kPC/E9Yd0wPtYTWguYI2JhmOV.Lmxg0d0skcP2IXDN3OU9jibaeUpjTLk66NCu3pT.',
+      )}
+    end
+  end
 end

--- a/spec/defines/user_spec.rb
+++ b/spec/defines/user_spec.rb
@@ -480,15 +480,49 @@ describe 'accounts::user', :type => :define do
       end
       it { is_expected.to compile.and_raise_error(/You cannot set both \$pwhash and \$password/) }
     end
-    describe 'without salt' do
+
+    # we need to provide different hashes, as the fqdn_rand implementation differs
+    # between puppet versions...
+    hash = ''
+    if Gem::Version.new(Puppet.version) < Gem::Version.new("4.4.0")
+      hash = '$6$g9aYujG8oLQDJWBO$dNhF1lBTXpiG86V5Ra8nbzZIVmIioD293jZMHpA7bPHd34iIGPddfPWbjcX0bFVXRKA38LE1Z4K/Gqb4WNaxe/'
+    else
+      hash = '$6$qcmrAVy2N6yFHaD7$zAJCY8zAhLgeTe2bJ1Ui6pPXKTkJ..Qbx56tYhrVbZEbUiRG/hKLliAzvTQm3GlIds6DGncYFEJAd4w0HYxgV.'
+    end
+    describe 'without salt and empty fact' do
       let(:params) do
         {
           password: 'test1234',
         }
       end
-      it { is_expected.to compile.and_raise_error(/You need to specify a salt for hashing cleartext passwords./) }
+      let(:facts) do
+        {
+          :salts => {},
+          :fqdn  => 'testhost',
+          :osfamily => 'Debian',
+          :puppetversion => Puppet.version,
+        }
+      end
+      it { is_expected.to contain_user('foo').with(
+        'name'     => 'foo',
+        'password' => hash,
+      )}
     end
-    describe 'with salt' do
+    describe 'without salt and with fact' do
+      let(:params) { { :password => 'test1234' } }
+      let(:facts) do
+        {
+          :salts => { 'foo' => '7kjgdqd0uK3y8zJv' },
+          :osfamily => 'Debian',
+          :puppetversion => Puppet.version,
+        }
+      end
+      it { is_expected.to contain_user('foo').with(
+        'name'     => 'foo',
+        'password' => '$6$7kjgdqd0uK3y8zJv$jkPEoPrL8NTMfP60V9UGYf4I8l1EdsnCXOB2IAtOCGZmw4IX8MIji7kx9GsaUW1JifPhTVO1HjnSBHYfwVpZA.',
+      )}
+    end
+    describe 'with explicit salt' do
       let(:params) do
         {
           password: 'test1234',


### PR DESCRIPTION
Currently I manage local users with this puppet module. Recently I had the need to use cleartext passwords for such a user, as the password needed to be inserted into Samba users, too. As Samba does not use `/etc/shadow` passwords, I had to extend the module.

I would be glad if this would be merged into this great module.

Thanks,
Oliver