### PR TITLE
set authorized_keys directory so its actually used

### DIFF
--- a/manifests/authorized_keys.pp
+++ b/manifests/authorized_keys.pp
@@ -35,8 +35,6 @@ define accounts::authorized_keys(
     require => File[$auth_keys],
   }
 
-  anchor { "accounts::auth_keys_created_${title}": }
-
   # backwards compatibility only - will be removed in 2.0
   # see https://github.com/deric/puppet-accounts/issues/40
   if !empty($ssh_key) {
@@ -66,7 +64,6 @@ define accounts::authorized_keys(
         content => template("${module_name}/authorized_keys.erb"),
         require => [File["${home_dir}/.ssh"]],
       }
-      Ssh_authorized_key<| |> -> File[$auth_keys]
     }
   } else {
     file { $auth_keys:

--- a/manifests/authorized_keys.pp
+++ b/manifests/authorized_keys.pp
@@ -48,7 +48,6 @@ define accounts::authorized_keys(
       options => $ssh_key['options'],
       target  => $auth_keys,
       require => File[$auth_keys],
-      before  => Anchor["accounts::auth_keys_created_${title}"],
     }
   }
 
@@ -65,7 +64,7 @@ define accounts::authorized_keys(
         group   => $real_gid,
         mode    => '0600',
         content => template("${module_name}/authorized_keys.erb"),
-        require => [File["${home_dir}/.ssh"], Anchor["accounts::auth_keys_created_${title}"]],
+        require => [File["${home_dir}/.ssh"]],
       }
       Ssh_authorized_key<| |> -> File[$auth_keys]
     }

--- a/manifests/authorized_keys.pp
+++ b/manifests/authorized_keys.pp
@@ -30,7 +30,9 @@ define accounts::authorized_keys(
   $ssh_key_defaults = {
     ensure  => present,
     user    => $username,
-    'type'  => 'ssh-rsa',
+    target  => $auth_keys,
+    type    => 'ssh-rsa',
+    require => File[$auth_keys],
   }
 
   anchor { "accounts::auth_keys_created_${title}": }
@@ -44,7 +46,8 @@ define accounts::authorized_keys(
       type    => $ssh_key['type'],
       key     => $ssh_key['key'],
       options => $ssh_key['options'],
-      require =>  File[$auth_keys],
+      target  => $auth_keys,
+      require => File[$auth_keys],
       before  => Anchor["accounts::auth_keys_created_${title}"],
     }
   }

--- a/manifests/authorized_keys.pp
+++ b/manifests/authorized_keys.pp
@@ -31,7 +31,7 @@ define accounts::authorized_keys(
     ensure  => present,
     user    => $username,
     target  => $auth_keys,
-    type    => 'ssh-rsa',
+    'type'  => 'ssh-rsa',
     require => File[$auth_keys],
   }
 


### PR DESCRIPTION
Before this commit, you could specify a authorized_keys directory, but it would only be created, not actually used, unless you specified twice:

```yaml
accounts::users:
  user:
    authorized_keys_file: '/etc/ssh/authorized_keys_user'
    comment: "foo Bar"
    ssh_keys:
      'user':
        target: "/etc/ssh/authorized_keys_user"
        type: "ssh-rsa"
        key: "asdjsjgiov"
```

I don't know why the test "supply custom path to authorized_keys file outside of home dir" doesn't catch this, but I guess, because the target-option for `ssh_authorized_keys` is missing and the test looks for the key in the home-directory, where its created.
I can't test it myself, either.

Anyway, now it works like this:

```yaml
accounts::users:
  user:
    authorized_keys_file: '/etc/ssh/authorized_keys_user'
    comment: "foo Bar"
    ssh_keys:
      'user':
        type: "ssh-rsa"
        key: "asdjsjgiov"
```

Additionally a needed dependency was set so the authorized_keys-file gets created before trying to insert keys into it.