### PR TITLE
Pass secondary groups when creating a user

### DIFF
--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -196,6 +196,7 @@ define accounts::user(
         ensure    => present,
         uid       => $uid,
         shell     => $shell,
+        groups    => $groups,
         allowdupe => $allowdupe,
       }
 


### PR DESCRIPTION
Created users should be assigned to secondary groups; pass the groups parameter to the user resource.

Note: I had to set manage_groups: false so that the accounts module no longer creates the secondary groups, this was to prevent a dependency loop:
```
Error: Failed to apply catalog: Found 1 dependency cycle:
(Group[sudo] => User[ubuntu] => Accounts::Group[sudo] => Group[sudo])
```