### PR TITLE
Move `salts` fact logic into the `setcode` block

### DIFF
--- a/lib/facter/salts.rb
+++ b/lib/facter/salts.rb
@@ -4,13 +4,13 @@ Facter.add('salts') do
   confine :facterversion do |version|
     Gem::Version.new(version) >= Gem::Version.new('2.0.0')
   end
-  # read
-  shadow = Facter::Util::Resolution.exec('cat /etc/shadow')
-  # split into line array
-  lines = shadow.split('\n')
-  # create a new hash for {username => salt}
-  salts = Hash.new
   setcode do
+    # read
+    shadow = Facter::Util::Resolution.exec('cat /etc/shadow')
+    # split into line array
+    lines = shadow.split('\n')
+    # create a new hash for {username => salt}
+    salts = Hash.new
     # parse every line
     lines.each do |l|
       parts = l.split(':')

--- a/metadata.json
+++ b/metadata.json
@@ -53,10 +53,6 @@
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
-    },
-    {
       "name": "puppet",
       "version_requirement": ">= 3.0.0 < 5.0.0"
     }


### PR DESCRIPTION
The shadow file should not be read if it does not exist. The `confine` should take care of it, but that means all code that needs to be confined also needs to be moved into the `setcode` block. This change simply moves those two lines (`cat` and `split`) into the `setcode` block.

#75 and #76 were set to deal with this problem, but there does not appear to be any activity there and I would like to have this resolved on here so that we can get a nice update on Forge that deals with this.