### PR TITLE
changed attribute_membership to auth_members

### DIFF
--- a/manifests/group.pp
+++ b/manifests/group.pp
@@ -30,9 +30,9 @@ define accounts::group (
 
   # avoid problems when group declared elsewhere
   ensure_resource('group', $groupname, {
-    'ensure'  => $ensure,
-    'gid'     => $gid,
-    'members' => sort(unique($members)),
-    'attribute_membership' => 'inclusive',
+    'ensure'          => $ensure,
+    'gid'             => $gid,
+    'members'         => sort(unique($members)),
+    'auth_membership' => true,
   })
 }

--- a/manifests/group.pp
+++ b/manifests/group.pp
@@ -19,10 +19,11 @@
 # Definition of a Linux/Unix group
 #
 define accounts::group (
-  $groupname = $title,
-  $ensure    = 'present',
-  $members   = [],
-  $gid       = undef,
+  $groupname       = $title,
+  $ensure          = 'present',
+  $members         = [],
+  $gid             = undef,
+  $auth_membership = true,
 ) {
 
   validate_re($ensure, [ '^absent$', '^present$' ],
@@ -33,6 +34,6 @@ define accounts::group (
     'ensure'          => $ensure,
     'gid'             => $gid,
     'members'         => sort(unique($members)),
-    'auth_membership' => true,
+    'auth_membership' => $auth_membership,
   })
 }


### PR DESCRIPTION
I tracked this down after chasing an issue with the group resource type under certain conditions that fails to recognise a group as in sync if it's members aren't in alphabetical order.  The behaviour only happens when `attribute_membership` is set to `inclusive`.

After looking at this for a while, it looks as if this is the wrong attribute to use for what is trying to be achieved and is in fact something only really implemented for the AIX provider.  This is highlighted by a recent documentation ticket https://tickets.puppetlabs.com/browse/DOCUMENT-356 where the group types docs have now been updated (see https://github.com/puppetlabs/puppet/pull/5765) 

I believe changing this to `auth_membership => true` is correct.  (it also solves the strange behaviour I was seeing on RHEL)


