### PR TITLE
added forcelocal option

### DIFF
--- a/manifests/group.pp
+++ b/manifests/group.pp
@@ -24,6 +24,7 @@ define accounts::group (
   $members         = [],
   $gid             = undef,
   $auth_membership = true,
+  $forcelocal      = false,
 ) {
 
   validate_re($ensure, [ '^absent$', '^present$' ],
@@ -35,5 +36,6 @@ define accounts::group (
     'gid'             => $gid,
     'members'         => sort(unique($members)),
     'auth_membership' => $auth_membership,
+    'forcelocal'      => $forcelocal,
   })
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,5 +48,6 @@ class accounts(
     # No anchor is needed, all requirements are defined individially for each resource
     $members = accounts_group_members($_users, $_groups, $default_groups)
     create_resources(accounts::group, $members)
+    Accounts::Group<| |> -> Accounts::User<| |>
   }
 }

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -36,6 +36,7 @@
 #                     Should not be changed unless you're moving out of user's home.
 #  * [ssh_dir_group] (default: `user`) owner of `.ssh` directory (and `authorized_keys` file in the directory).
 #  * [manage_ssh_dir] Whether `.ssh` directory should be managed by this module (default: `true`)
+#  * [forcelocal] (optional, default false) Forces the management of local accounts
 #
 define accounts::user(
   $uid = undef,
@@ -72,6 +73,7 @@ define accounts::user(
   $allowdupe = false,
   $home_permissions = '0700',
   $manage_ssh_dir = true,
+  $forcelocal = false,
   $ssh_dir_owner = undef,
   $ssh_dir_group = undef,
 ) {
@@ -194,10 +196,11 @@ define accounts::user(
       }
 
       user { $username:
-        ensure    => present,
-        uid       => $uid,
-        shell     => $shell,
-        allowdupe => $allowdupe,
+        ensure     => present,
+        uid        => $uid,
+        shell      => $shell,
+        allowdupe  => $allowdupe,
+        forcelocal => $forcelocal,
       }
 
       # Set password if available


### PR DESCRIPTION
Adding the forcelocal option so the OS doesn't try to update LDAP when making user or group changes.  The resource collector was added to the init.pp manifest so when creating local accounts, the group is created first.