### PR TITLE
Implement ssh_key_groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,34 @@ accounts::users:
           - 'command="/path/to/script.sh arg1 $SSH_ORIGINAL_COMMAND"'
 ```
 
+### SSH key groups
+
+Alternatively to specify the ssh keys for every user, they can be specified in groups in a seperate structure. Those groups can then be included for individual users.
+
+```yaml
+accounts::ssh_key_groups:
+  mykey_group1:
+    mykey1:
+      type: 'ssh-rsa'
+      key: 'AAAA....'
+    mykey2:
+      type: 'ssh-rsa'
+      key: 'AAAA....'
+  mykey_group2:
+    mykey3:
+      type: 'ssh-rsa'
+      key: 'AAAA....'
+
+accounts::users:
+  foo:
+    ssh_key_groups: ['mykey_group1', 'mykey_group2']
+    ssh_keys:
+      'mykey4':
+        type: 'ssh-rsa'
+        key: 'AAAA....'
+```
+
+
 ### Password Management
 
 You can either provide an already hashed password or you can let the module take

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,13 +1,14 @@
 # Puppet accounts management
 #
 class accounts(
-  Boolean $manage_users  = true,
-  Boolean $manage_groups = true,
-  Hash    $users         = {},
-  Hash    $groups        = {},
-  Hash    $user_defaults = {},
-  Hash    $options       = {},
-  Boolean $use_lookup    = true,
+  Boolean $manage_users   = true,
+  Boolean $manage_groups  = true,
+  Hash    $users          = {},
+  Hash    $groups         = {},
+  Hash    $user_defaults  = {},
+  Hash    $options        = {},
+  Hash    $ssh_key_groups = {},
+  Boolean $use_lookup     = true,
 ) inherits ::accounts::params {
 
   # currently used mainly in tests to turn-off hiera backends

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -47,6 +47,7 @@ define accounts::user(
   Array                              $groups = [],
   Optional[Stdlib::Absolutepath]     $ssh_key_source = undef,
   Hash                               $ssh_keys = {},
+  Array                              $ssh_key_groups = [],
   Boolean                            $purge_ssh_keys = false,
   String                             $shell ='/bin/bash',
   String                             $pwhash = '',
@@ -247,8 +248,16 @@ define accounts::user(
           }
         }
 
+        $mapped_ssh_keys = $ssh_key_groups.reduce({}) |$memo, $key_group| {
+          if ($key_group in $accounts::ssh_key_groups) {
+            $memo + $accounts::ssh_key_groups[$key_group]
+          } else {
+            fail("Accounts:user ${username}: ssh_key_group ${key_group} does not exist!")
+          }
+        }
+
         accounts::authorized_keys { $username:
-          ssh_keys             => $ssh_keys,
+          ssh_keys             => $mapped_ssh_keys + $ssh_keys,
           ssh_key_source       => $ssh_key_source,
           authorized_keys_file => $authorized_keys_file,
           home_dir             => $home_dir,


### PR DESCRIPTION
This allows to specify ssh_keys in groups seperate from the users. This
helps to avoid duplication if the same keys are used on different
systems in different profiles.